### PR TITLE
Add Docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+### Example user template template
+### Example user template
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang AS builder
+WORKDIR /go/src/app
+COPY am2pushbullet.go .
+ENV CGO_ENABLED=0
+RUN go mod init && go get -v && go mod download && go build -o /go/bin/am2pushbullet .
+
+FROM alpine
+COPY entrypoint.sh /
+COPY --from=builder /go/bin/am2pushbullet /
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -9,12 +9,43 @@ No templating or fancy features for now, but these may be included in due course
 perhaps also export metrics for alerts sent (and maybe Pushbullet's token allowance
 left).
 
-Usage
-===
+## Usage
+
+Do note that Pushbullet limits pushed from free accounts to 500/month.
+
+### Docker
+
+You'll probably be deploying Alertmanager as part of a docker-compose stack, add the following in your stack:
+
+```yaml
+version: '2.1'
+services:
+ ...
+ pushbullet-gateway:
+    image: buxtronix/am2pushbullet:latest
+    container_name: pushbullet-gateway
+    restart: unless-stopped
+    environment:
+      - PUSHBULLET_KEY=<you Pushbullet API key>
+    expose:
+      - 5001
+```
+
+Then, configure it as a webhook endpoint in alertmanager.yml:
+
+```yaml
+- name: 'default-receiver'
+  webhook_configs:
+  - url: http://pushbullet-gateway:5001/alert
+```
+
+That's it!
+
+### Compile yourself
 
 Configure as a webhook endpoint in alertmanager.yml:
 
-```
+```yaml
 - name: 'default-receiver'
   webhook_configs:
   - url: http://127.0.0.1:5001/alert
@@ -24,7 +55,7 @@ Set the host/port in the URL to match where this gateway is running.
 
 Build the gateway:
 
-```
+```console
 $ go get github.com/prometheus/alertmanager/template
 $ go get github.com/xconstruct/go-pushbullet
 $ go build am2pushbullet.go
@@ -32,13 +63,11 @@ $ go build am2pushbullet.go
 
 Run the gateway with at least the API key flag, use your [API key](https://www.pushbullet.com/#settings):
 
-```
+```console
 $ ./am2pushbullet -api_key o.sdf923456fs765dfsfsdf
 ```
 
 That's it!
-
-Do note that Pushbullet limits pushed from free accounts to 500/month.
 
 Licence
 ===

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+/am2pushbullet -api_key $PUSHBULLET_KEY


### PR DESCRIPTION
Hello,

For my own use with [stefanprodan/dockprom](/stefanprodan/dockprom), I added the capability to build a Docker image from the project and added instructions to add it in a Docker Compose stack as well.

Instructions to build the image are not present as I do not know if you want to create a Docker Hub repository for it or if you prefer users to build the image on their own.

I'm available if you have any question.